### PR TITLE
Enable configuration override of job plugin defaults (tests not updated)

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -5,6 +5,13 @@ module.exports = {
   webapp: webapp
 }
 
+function defExtend(dest, src) {
+  for (var key in src) {
+    if (!src[key]) continue;
+    dest[key] = src[key]
+  }
+}
+
 // schema
 // {
 //    routes: function (app, context) {}
@@ -12,6 +19,9 @@ module.exports = {
 //    listen: function (io, context) {}
 // }
 function webapp(id, plugin, striderjson, context, done) {
+  if (plugin.appConfig) {
+    defExtend(plugin.appConfig, context.config.plugins[id] || {})
+  }
   // setup routes
   if (plugin.routes) {
     jobRoutes(id, plugin, context)


### PR DESCRIPTION
I spent ages trying to figure out:
1. How to configure strider-heroku's client id and secret
2. Why PLUGIN_HEROKU_CLIENT_ID and PLUGIN_HEROKU_CLIENT_SECRET didn't get through to strider-heroku

Finally realised lib/provider.js is the only one that overrides a plugin's appConfig with config.plugins.<plugin>.*.  So I've copied it's defExtend function and execution to lib/job.js.  I'm not familiar, yet, with Strider's plugin structure, so not sure if it needs to be spread to more places.

I also haven't written a test yet - maybe a kind soul could help me figure out how to test this particularly piece of functionality?

With this patch, you can now configure your heroku client id and secret with:
PLUGIN_HEROKU_CLIENT_ID and PLUGIN_HEROKU_CLIENT_SECRET
