### PR TITLE
Upgrading less usage to Version 2

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,12 +53,14 @@ function getStatic(id, basedir, config, name, lesspaths, done) {
           return next(null, text + source)
         }
         var fpath = path.join(basedir, config.style || name + '.less')
-        new (less.Parser)({
+        
+        less.render(text, {
           paths: [path.dirname(fpath)].concat(lesspaths || []),
           filename: fpath
-        }).parse(text, function (err, tree) {
-          if (err) return next(err)
-          next(null, tree.toCSS() + source)
+        }).then(function(output) {
+          next(null, output.css + source)
+        }, function(error) {
+          next(error)
         })
       })
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "step": "~0.0.5",
     "async": "~0.2.6",
     "methods": "0.0.1",
-    "less": "~1.4.2",
+    "less": "^2.2.0",
     "underscore": "~1.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
On one of my projects we were upgrading strider to latest, and due to incompatibilities of the published version we cloned master and ran from that instead (which seems to be the common advice in a number of issues on Strider-CD/strider. Anyway, we did that, however strider-extension-loader was crashing due to relying on less 1.x whilst less 2.x being the dependency that came in with `npm install`. 

This change seems to have fixed things for us at least, figured we'd send a pull request if it makes sense for you to merge it in.